### PR TITLE
Register user blueprint

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -6,12 +6,14 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 from flask import Flask, send_from_directory, session
 from src.routes.main_routes import main_bp
+from src.routes.user import user_bp
 
 app = Flask(__name__, static_folder=os.path.join(os.path.dirname(__file__), 'static'), template_folder='templates')
 app.config['SECRET_KEY'] = os.urandom(24)
 
 # Register blueprints
 app.register_blueprint(main_bp)
+app.register_blueprint(user_bp)
 
 # Make session and current_year available to all templates
 @app.context_processor


### PR DESCRIPTION
## Summary
- import and register `user_bp` in `src/main.py`

## Testing
- `pytest -q`
- `python3 -m py_compile src/main.py src/routes/user.py`
- manual check of `/users` endpoints with in-memory SQLite

------
https://chatgpt.com/codex/tasks/task_e_6850fa4027ec83208643a891fbc078ec