### PR TITLE
Read SECRET_KEY from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# BaiMuras Website
+
+This repository contains a simple Flask-based website for BaiMuras. You can run it locally using Python.
+
+## Setup
+
+1. Create and activate a virtual environment.
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. **Set the `SECRET_KEY` environment variable** before starting the application. This is required in production to keep sessions secure. You can generate a key with Python:
+   ```bash
+   export SECRET_KEY=$(python -c 'import secrets; print(secrets.token_hex(16))')
+   ```
+
+## Running
+
+Run the application with:
+```bash
+python wsgi.py
+```
+
+During development, if `SECRET_KEY` is not set, the app will generate a temporary key and display a warning. In production, the application will fail to start without `SECRET_KEY`.

--- a/src/main.py
+++ b/src/main.py
@@ -8,7 +8,16 @@ from flask import Flask, send_from_directory, session
 from src.routes.main_routes import main_bp
 
 app = Flask(__name__, static_folder=os.path.join(os.path.dirname(__file__), 'static'), template_folder='templates')
-app.config['SECRET_KEY'] = os.urandom(24)
+secret_key = os.environ.get("SECRET_KEY")
+if not secret_key:
+    if os.environ.get("FLASK_ENV") == "production":
+        raise RuntimeError("SECRET_KEY environment variable must be set in production")
+    secret_key = os.urandom(24)
+    print(
+        "WARNING: SECRET_KEY not set. Using a generated key for development only",
+        file=sys.stderr,
+    )
+app.config["SECRET_KEY"] = secret_key
 
 # Register blueprints
 app.register_blueprint(main_bp)


### PR DESCRIPTION
## Summary
- load `SECRET_KEY` from env var in main flask app
- warn or fail if missing depending on FLASK_ENV
- document `SECRET_KEY` requirement in README

## Testing
- `PYTHONDONTWRITEBYTECODE=1 python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6850fa39dc8c8320827ee8cc8383e018